### PR TITLE
IPv6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ### Docker
 1. Get the [example config file](./example-config.toml) onto your server
-1. Run `docker run -p 5000:5000 -v \`pwd\`/config.toml:/app/config.toml:ro unifiedpush/common-proxies`. While changing parameters like the port and the config file location to the appropriate values.
+1. Run `docker run -p 5000:5000 -v $PWD/config.toml:/app/config.toml:ro unifiedpush/common-proxies`. While changing parameters like the port and the config file location to the appropriate values.
 1. Install the [reverse-proxy](#reverse-proxy)
 
 
@@ -34,7 +34,6 @@ This is meant to be hosted by the app developers or someone who has access to th
 This is primarily meant to be hosted on the same machine as the Gotify server. Running it on a different machine hasn't been tested yet but you can share information about that in this repo's issues.
 
 ## Gateway
-Note: Gateways cannot connect to localhost or other private IPs. IPv6 support missing is a known bug.
 
 ### Matrix
 Gateways matrix push until [MSC 2970](https://github.com/matrix-org/matrix-doc/pull/2970) is accepted.  

--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,5 @@ require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/stretchr/testify v1.7.0
 )
+
+replace github.com/hakobe/paranoidhttp => github.com/karmanyaahm/paranoidhttp v0.2.1-0.20210628044206-c40d6edc4d56

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/hakobe/paranoidhttp v0.2.0 h1:0UPuT7Vo4jkoGSJCOnPWSDc4V05q/7Q15i9N81/0asE=
 github.com/hakobe/paranoidhttp v0.2.0/go.mod h1:f9cFbB2hM4ZcEgWu0zw9+hjzk5kG/Ys8jxEmyMBBeqk=
+github.com/karmanyaahm/paranoidhttp v0.2.1-0.20210628044206-c40d6edc4d56 h1:hFVkLRVbV5WEXdoTDjBj7kR59WA1FFVhs4qBUyRthDc=
+github.com/karmanyaahm/paranoidhttp v0.2.1-0.20210628044206-c40d6edc4d56/go.mod h1:f9cFbB2hM4ZcEgWu0zw9+hjzk5kG/Ys8jxEmyMBBeqk=
 github.com/komkom/toml v0.0.0-20210317065440-24f427ca88cc h1:qqbeoQ7wVR5NFIGyJdz/PQjuCBzpg8GxOaF0HWivFMk=
 github.com/komkom/toml v0.0.0-20210317065440-24f427ca88cc/go.mod h1:wLcNqnyr6riTbnFObg4o2/GemTCso9AnsUdLsMsdspw=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=

--- a/main_test.go
+++ b/main_test.go
@@ -49,7 +49,7 @@ func (s *RewriteTests) TearDownTest() {
 func (s *RewriteTests) TestFCM() {
 	fcm := rewrite.FCM{Key: "testkey", APIURL: s.ts.URL}
 
-	request := httptest.NewRequest("POST", "/FCM?token=a", bytes.NewBufferString("content"))
+	request := httptest.NewRequest("POST", "/?token=a", bytes.NewBufferString("content"))
 	handle(&fcm)(s.Resp, request)
 
 	//resp
@@ -65,7 +65,7 @@ func (s *RewriteTests) TestGotify() {
 	testurl, _ := url.Parse(s.ts.URL)
 	gotify := rewrite.Gotify{Address: testurl.Host, Scheme: testurl.Scheme}
 
-	request := httptest.NewRequest("POST", "/UP?token=a", bytes.NewBufferString("content"))
+	request := httptest.NewRequest("POST", "/?token=a", bytes.NewBufferString("content"))
 	handle(&gotify)(s.Resp, request)
 
 	//resp
@@ -82,7 +82,7 @@ func (s *RewriteTests) TestMatrixSend() {
 	matrix := gateway.Matrix{}
 
 	content := `{"notification":{"devices":[{"pushkey":"` + s.ts.URL + `"}]}}`
-	request := httptest.NewRequest("POST", "/UP?token=a", bytes.NewBufferString(content))
+	request := httptest.NewRequest("POST", "/", bytes.NewBufferString(content))
 	handle(&matrix)(s.Resp, request)
 
 	//resp


### PR DESCRIPTION
- upgrade ParanoidHTTP to version with ipv6 support
- URL path doesn't matter in these tests (minor unrelated change)

Closes #2 