### PR TITLE
Fix parsing the command-line flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ var configFile = flag.String("c", "config.toml", "path to toml file for config")
 var handlers = []Handler{}
 
 func main() {
+	flag.Parse()
 	err := ParseConf(*configFile)
 	if err != nil {
 		log.Fatalln(err)


### PR DESCRIPTION
The configFile variable would always evaluate to the default.