### PR TITLE
Simplify the build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -yq \
   curl \
   && rm -rf /var/lib/apt/lists/*
-ADD config.toml /app/
+ADD example-config.toml /app/config.toml
 COPY --from=build /src/up-rewrite /app/
 #HEALTHCHECK --interval=30s --timeout=5s --start-period=5s CMD curl --fail http://localhost:$UP_PROXY_SERVER_PORT/UP || exit 1
 #TODO

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,7 @@ test-docker:
 	$(DOCKER_CMD) go test ./...
 
 # check out this if the cross-docker things don't work https://stackoverflow.com/a/65371609/8919142
-prep-build:
-	cp example-config.toml config.toml
-build-local: prep-build
+
+build-local:
 	docker build . -t unifiedpush/common-proxies:testing
-	rm config.toml
 


### PR DESCRIPTION
This small change allows for a simple build directive in docker-compose, e.g.
`build: https://github.com/UnifiedPush/common-proxies.git#main`